### PR TITLE
Updated for new URL defaults, use ubuntu 20.04, and stripping ' from …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 #FROM avare-repo-bash
 
 # Add crontab file in the cron directory

--- a/app/input.txt
+++ b/app/input.txt
@@ -1,3 +1,3 @@
-http://www.apps4av.org/new/weather.zip
-http://www.apps4av.org/new/conus.zip
-http://www.apps4av.org/new/TFRs.zip
+http://www.apps4av.org/regions/weather.zip
+http://www.apps4av.org/regions/conus.zip
+http://www.apps4av.org/regions/TFRs.zip

--- a/app/repo_setup.py
+++ b/app/repo_setup.py
@@ -49,7 +49,7 @@ def get_version(url):
 
 def main():
     print(f'[{datetime.datetime.now()}] running avare repo download.')
-    url = URL(os.environ["REPO"])
+    url = URL(os.environ["REPO"].strip("'"))
     version = get_version(url)
     # dir_path = './' # For local testing
     dir_path = '/config/www/' # For Docker Container


### PR DESCRIPTION
- The apps4av.org URL changed, so updated the defaults for that. 
- As is, this has dependencies that are easily resolved by sticking to Ubuntu 20.04, so updated Dockerfile to use that.
- using the REPO env in the docker-compose failed. Strip extraneous ' when building the URL
